### PR TITLE
Bugfix: Fixed GPIO pin mode configuration and begin()

### DIFF
--- a/qwiic_gpio.py
+++ b/qwiic_gpio.py
@@ -94,8 +94,8 @@ class QwiicGPIO(object):
     REG_CONFIGURATION = 0x03
 
     # Status/Configuration Flags
-    GPIO_IN = 0
-    GPIO_OUT = 1
+    GPIO_OUT = 0
+    GPIO_IN = 1
 
     GPIO_LO = 0
     GPIO_HI = 1
@@ -196,14 +196,14 @@ class QwiicGPIO(object):
 
         """
         tempData = 0
-        tempData &= self.mode_0 << 0
-        tempData &= self.mode_1 << 1
-        tempData &= self.mode_2 << 2
-        tempData &= self.mode_3 << 3
-        tempData &= self.mode_4 << 4
-        tempData &= self.mode_5 << 5
-        tempData &= self.mode_6 << 6
-        tempData &= self.mode_7 << 7
+        tempData |= self.mode_0 << 0
+        tempData |= self.mode_1 << 1
+        tempData |= self.mode_2 << 2
+        tempData |= self.mode_3 << 3
+        tempData |= self.mode_4 << 4
+        tempData |= self.mode_5 << 5
+        tempData |= self.mode_6 << 6
+        tempData |= self.mode_7 << 7
         self._i2c.writeByte(self.address, self.REG_CONFIGURATION, tempData)
 
     #----------------------------------------------------------------

--- a/qwiic_gpio.py
+++ b/qwiic_gpio.py
@@ -182,7 +182,7 @@ class QwiicGPIO(object):
 
         """
         
-        return isConnected()
+        return self.isConnected()
 
     #----------------------------------------------------------------
     # setMode()


### PR DESCRIPTION
Hi all,

I recently got the Qwiic GPIO expansion and found that I could not get the board to read incoming GPIO signals. Further investigation revealed that despite whatever I passed to `setMode()`, `getMode()` would always return `0`. When I looked into the code and checked with the TCA9534 datasheet I found that

1.  `setMode()` had a bitwise AND instead of a bitwise OR and thus `tempData` was always `0`, so pin modes were never actually being configured.
2. According to page 20 of the TCA9534 datasheet, a configuration bit value of `1` actually corresponds to *input* and not *output*. Thus the `GPIO_IN` and `GPIO_OUT` values are actually flipped.

I have tested these changes on my Qwiic GPIO expansion and it has enabled me to finally read digital input signals.